### PR TITLE
Fix typo in git config section name

### DIFF
--- a/src/cli/public.rs
+++ b/src/cli/public.rs
@@ -32,7 +32,7 @@ impl<C: Context> CommandContext<C> {
 
     pub(crate) fn deinit(&self) -> Result<()> {
         let repo = self.ctx.repo();
-        ensure_state(repo.remove_config_section("fiter.git-agecrypt"))?;
+        ensure_state(repo.remove_config_section("filter.git-agecrypt"))?;
         ensure_state(repo.remove_config_section("diff.git-agecrypt"))?;
 
         self.ctx.remove_sidecar_files()?;


### PR DESCRIPTION
This typo prevents the git config section `filter.git-agecrypt` from being deleted on `deinit`.