### PR TITLE
Fix: Fail to load/use identities if any other git config with `identity` substring is present

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-agecrypt"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/cli/internal.rs
+++ b/src/cli/internal.rs
@@ -71,9 +71,9 @@ impl<C: Context> CommandContext<C> {
         };
 
         if let Some(repo_contents) = repo_contents {
-            let identities = self.get_identities()?;
+            let all_identities = self.get_identities()?;
             let mut cur = io::Cursor::new(repo_contents);
-            let decrypted = age::decrypt(&identities, &mut cur)?.unwrap_or_default();
+            let decrypted = age::decrypt(&all_identities, &mut cur)?.unwrap_or_default();
             if decrypted == contents {
                 log::debug!("Decrypted content matches, using from working copy");
                 self.ctx.store_sidecar(&file, "hash", hash.as_bytes())?;
@@ -95,7 +95,14 @@ impl<C: Context> CommandContext<C> {
 
     fn get_identities(&self) -> Result<Vec<String>> {
         log::debug!("Loading identities from config");
-        let all_identities = self.ctx.repo().list_config("identity")?;
+        let all_identities: Vec<String> = self
+            .ctx
+            .age_identities()
+            .list()?
+            .into_iter()
+            .map(|i| i.path)
+            .collect();
+
         log::debug!(
             "Loaded identities from config; identities='{:?}'",
             all_identities
@@ -128,15 +135,7 @@ impl<C: Context> CommandContext<C> {
 
     pub(crate) fn textconv(&self, path: impl AsRef<Path>) -> Result<()> {
         log::info!("Decrypting file to show in diff");
-
-        let all_identities: Vec<String> = self
-            .ctx
-            .age_identities()
-            .list()?
-            .into_iter()
-            .map(|i| i.path)
-            .collect();
-
+        let all_identities: Vec<String> = self.get_identities()?;
         let mut f = File::open(path)?;
         let result = if let Some(rv) = age::decrypt(&all_identities, &mut f)? {
             log::info!("Decrypted file to show in diff");

--- a/src/config/git.rs
+++ b/src/config/git.rs
@@ -73,10 +73,11 @@ where
     }
 
     fn list(&self) -> Result<Vec<Self::Item>> {
+        let entry_name = format!("{}.{}", CONFIG_PATH, self.ns);
         Ok(self
             .ctx
             .repo()
-            .list_config(&self.ns)?
+            .list_config(&entry_name)?
             .into_iter()
             .map(GitConfigEntry::new)
             .collect())


### PR DESCRIPTION
Currently any `.git/config` key that has the word `identity` in it will get its value used as a `git-agecrypt` identity.  This is a major bug because all of the following keys get matched by this, and all of their values try to get used as a `git-agecrypt` identity (causing errors):
```
identity.username
identity.useremail
git-identity.username
git-identity.useremail
foo.xidentityx
bar.xyzidentityxyz.foo
```

Lots of other tools set keys that include the word "identity" and none of them should be automatically used as a `git-agecrypt` identity (e.g. `git-identity` tool).

---

The root of the issue is how the public `git2` crate's `entries()` function is getting called.  This is used in the sub-crate function `git::Repository::list_config()` to look for all git config values matching a provided key. However, the `git2::entries()` [is documented](https://docs.rs/git2/0.20.1/git2/struct.Config.html#method.entries) to take a `Some()` *glob* string, and returns the git config entries whose key is matched by that glob. That means it's doing a substring match against all the fully-pathed git config keys that are set.  


For some reason the `internal.rs` was calling `ctx.repo().list_config()` to directly look up config values by hardcoded string, and passing `"identity"`, rather than using the `ctx.age_identities()` function that's designed for doing exactly what we want.  

Additionally the `GitConfig` had a bug that the `lookup()` didn't add the `CONFIG_PATH` prefix to the `self.ns` like the  `add()` and `remove()` functions did, so it would trigger the same problem as what `internal.rs` was originally seeing.

(`ctx.age_identities()` indirectly calls `GitConfig::list()`)

---

Use the `age_identity()` function from the context, which is designed to get the identity list from the git config properly.  
Fix the `GitConfig::list()` to match the `add()` and `remove()` functions by prefixing the `CONFIG_PATH` to the `self.ns`.